### PR TITLE
Refactor/improve api docs

### DIFF
--- a/src/pages/apidocs.ejs
+++ b/src/pages/apidocs.ejs
@@ -1,261 +1,386 @@
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/1.1.0/marked.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/sanitize-html/1.26.0/sanitize-html.min.js"></script>
-    <link rel="stylesheet" href="/path/to/styles/default.min.css">
-<script src="/path/to/highlight.min.js"></script>
-<script>hljs.highlightAll();</script>
-    <title>API Documentation - Universe List</title>
-    <%- include ("./parts/head.ejs") %>
-  </head>
-  <%- include ("./parts/navbar.ejs") %>
-  <br><br><br><br><br><br><br>
-    <div class="container">
-          <h2><b>API Documentation</b></h2>
-          <p>This is the documentation to Universe List's API.</p><br><br><br><br><br>
-          <h3>GET Bot Information</h3>
-          <p>Returns all information on a bot.</p><br>
-          <pre><code class="language-plaintext">GET /api/bots/:id</code></pre><br><br>
-          <table class="table table-hover">
-          <thead>
-            <tr>
-              <th scope="col"><b>Property</b></th>
-              <th scope="col"><b>Type</b></th>
-              <th scope="col"><b>Description</b></th>
-            </tr>
-            <tbody class="bots-list-body" style="color: #D9E4EC;">
-                <td style="color: #D9E4EC;">id</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The ID of the targeted bot.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">username</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The username of the targeted bot.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">discriminator</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The discriminator of the targeted bot.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">avatar</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The avatar URL of the targeted bot.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">prefix</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The prefix of the targeted bot.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">owner</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The ID of the targeted bot's owner.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">ownerTag</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The tag of the targeted bot's owner.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">tags</td>
-                <td style="color: #D9E4EC;">Array</td>
-                <td style="color: #D9E4EC;">An array of the targeted bot's tags.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">views</td>
-                <td style="color: #D9E4EC;">Integer</td>
-                <td style="color: #D9E4EC;">The amount of views the targeted bot's page has gotten.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">submittedOn</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The date the targeted bot was submitted to Universe List.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">approvedOn</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The date the targeted bot was approved on Universe List.</td> 
-                <tr></tr>
-                <td style="color: #D9E4EC;">shortDescription</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The short description of the targeted bot on Universe List.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">description</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The description of the targeted bot on Universe List.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">shards</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The number of shards the targeted bot has.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">servers</td>
-                <td style="color: #D9E4EC;">Integer</td>
-                <td style="color: #D9E4EC;">The number of servers the targeted bot has.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">votes</td>
-                <td style="color: #D9E4EC;">Integer</td>
-                <td style="color: #D9E4EC;">The number of vots the targeted bot has on Universe List.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">invite</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The invite of the targeted bot.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">website</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The website of the targeted bot.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">github</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The github of the targeted bot.</td>
-                <tr></tr>
-                <td style="color: #D9E4EC;">support</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The support server of the targeted bot.</td>
-                </tbody>
-          </thead>
-        </table><br><br><br>
-        <h3>POST Bot Stats</h3>
-        <p>Posts your bot's server and shard count.</p><br>
-        <pre><code class="language-plaintext">POST /api/bots/:id</code></pre><br><br>
-        <table class="table table-hover">
-            <thead>
-              <tr>
-                <th scope="col"><b>Header</b></th>
-                <th scope="col"><b>Type</b></th>
-                <th scope="col"><b>Description</b></th>
-              </tr>
-              <td style="color: #D9E4EC;">authorization</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The API Key for the targeted bot.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">server_count</td>
-              <td style="color: #D9E4EC;">Integer</td>
-              <td style="color: #D9E4EC;">The server count for the targeted bot.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">shard_count</td>
-              <td style="color: #D9E4EC;">Integer</td>
-              <td style="color: #D9E4EC;">The shard count for the targeted bot.</td>
-          </thead>
-        </table><br><br>
-        <h3>GET Bot Votes</h3>
-        <p>Get all votes of a bot on Universe List.</p><br>
-        <pre><code class="language-plaintext">GET /api/bots/:id/votes</code></pre><br><br>
-        <table class="table table-hover">
-            <thead>
-              <tr>
-                <th scope="col"><b>Property</b></th>
-                <th scope="col"><b>Type</b></th>
-                <th scope="col"><b>Description</b></th>
-              </tr>
-              <td style="color: #D9E4EC;">user</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The user ID who voted for the bot.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">current</td>
-              <td style="color: #D9E4EC;">Integer</td>
-              <td style="color: #D9E4EC;">The date the user voted.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">next</td>
-              <td style="color: #D9E4EC;">Integer</td>
-              <td style="color: #D9E4EC;">The time unitl they can vote again.</td>
-          </thead>
-        </table><br><br>
-        <h3>Check Vote</h3>
-        <p>Check if a user voted for your bot.</p><br>
-        <pre><code class="language-plaintext">GET /api/bots/:id/voted/?user=userid</code></pre><br><br>
-        <table class="table table-hover">
-            <thead>
-              <tr>
-                <th scope="col"><b>Property</b></th>
-                <th scope="col"><b>Type</b></th>
-                <th scope="col"><b>Description</b></th>
-              </tr>
-              <td style="color: #D9E4EC;">vote</td>
-                <td style="color: #D9E4EC;">Boolean</td>
-                <td style="color: #D9E4EC;">If the user voted or not.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">current</td>
-              <td style="color: #D9E4EC;">Integer</td>
-              <td style="color: #D9E4EC;">The date the user voted.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">next</td>
-              <td style="color: #D9E4EC;">Integer</td>
-              <td style="color: #D9E4EC;">The time unitl they can vote again.</td>
-          </thead>
-        </table><br><br>
-        <h3>GET Server Information</h3>
-        <p>Returns all information on a server.</p><br>
-        <pre><code class="language-plaintext">GET /api/servers/:id</code></pre><br><br>
-        <table class="table table-hover">
-            <thead>
-              <tr>
-                <th scope="col"><b>Property</b></th>
-                <th scope="col"><b>Type</b></th>
-                <th scope="col"><b>Description</b></th>
-              </tr>
-              <td style="color: #D9E4EC;">name</td>
-              <td style="color: #D9E4EC;">String</td>
-              <td style="color: #D9E4EC;">The name of the targeted server.</td>
-            <tr></tr>
-              <td style="color: #D9E4EC;">id</td>
-                <td style="color: #D9E4EC;">String</td>
-                <td style="color: #D9E4EC;">The ID of the targeted server.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">members</td>
-              <td style="color: #D9E4EC;">Integer</td>
-              <td style="color: #D9E4EC;">The member count of the targeted server.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">icon</td>
-              <td style="color: #D9E4EC;">String</td>
-              <td style="color: #D9E4EC;">The icon URL of the targeted server.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">invite</td>
-              <td style="color: #D9E4EC;">String</td>
-              <td style="color: #D9E4EC;">The invite URL of the targeted server.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">submittedOn</td>
-              <td style="color: #D9E4EC;">String</td>
-              <td style="color: #D9E4EC;">The submitted date of the targeted server.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">website</td>
-              <td style="color: #D9E4EC;">String</td>
-              <td style="color: #D9E4EC;">The website URL of the targeted server.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">owner</td>
-              <td style="color: #D9E4EC;">String</td>
-              <td style="color: #D9E4EC;">The owner ID of the targeted server.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">ownerTag</td>
-              <td style="color: #D9E4EC;">String</td>
-              <td style="color: #D9E4EC;">The owner tag of the targeted server.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">tags</td>
-              <td style="color: #D9E4EC;">Array</td>
-              <td style="color: #D9E4EC;">All of the tags of the targeted server.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">bump</td>
-              <td style="color: #D9E4EC;">Date</td>
-              <td style="color: #D9E4EC;">The latest bump date of the targeted server.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">bumps</td>
-              <td style="color: #D9E4EC;">Integer</td>
-              <td style="color: #D9E4EC;">The number of bumps of the targeted server.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">views</td>
-              <td style="color: #D9E4EC;">Integer</td>
-              <td style="color: #D9E4EC;">The number of views of the targeted server.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">votes</td>
-              <td style="color: #D9E4EC;">Integer</td>
-              <td style="color: #D9E4EC;">The number of votes of the targeted server.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">shortDesc</td>
-              <td style="color: #D9E4EC;">String</td>
-              <td style="color: #D9E4EC;">The short description of the targeted server.</td>
-              <tr></tr>
-              <td style="color: #D9E4EC;">description</td>
-              <td style="color: #D9E4EC;">String</td>
-              <td style="color: #D9E4EC;">The description of the targeted server.</td>
-              <tr></tr>
-          </thead>
-        </table><br><br>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/1.1.0/marked.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/sanitize-html/1.26.0/sanitize-html.min.js"></script>
+  <link rel="stylesheet" href="/path/to/styles/default.min.css">
+  <script src="/path/to/highlight.min.js"></script>
+  <script>
+    hljs.highlightAll();
+  </script>
+  <title>API Documentation - Universe List</title>
+  <%- include ("./parts/head.ejs") %>
+</head>
+<%- include ("./parts/navbar.ejs") %>
+<br><br><br><br><br><br><br>
+<div class="container">
+  <h2><b>API Documentation</b></h2>
+  <p>Welcome to the documentation for Universe List's API!<br>Please note that certain endpoints may require an API
+    key,
+    you can obtain yours by navigating to your bots edit page.</p><br><br>
 
-        <h3>Universe List NPM Package</h3>
-        <p>Find our NPM Package <a href="https://www.npmjs.com/package/universe-list.js">here</a> to learn how to interact with our API.</p>
-        <br><br>
-      </div>
+  <h3>GET Bot Information</h3>
+  <p>Returns all information on a bot.</p>
+  <strong>
+    <code class="endpoint">GET /api/bots/:id</code>
+  </strong><br><br>
+  <h4>Path Parameters</h4>
+  <table class="table table-hover">
+    <thead>
+      <th scope="col"><b>Name</b></th>
+      <th scope="col"><b>Type</b></th>
+      <th scope="col"><b>Description</b></th>
+    </thead>
+    <tbody>
+      <td style="color: #D9E4EC;">id</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">ID of the bot to get information of.</td>
+    </tbody>
+  </table>
+  <h4>Response</h4>
+  <table class="table table-hover">
+    <thead>
+      <th scope="col"><b>Name</b></th>
+      <th scope="col"><b>Type</b></th>
+      <th scope="col"><b>Description</b></th>
+    </thead>
+    <tbody>
+      <td style="color: #D9E4EC;">id</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The ID of the targeted bot.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">username</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The username of the targeted bot.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">discriminator</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The discriminator of the targeted bot.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">avatar</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The avatar URL of the targeted bot.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">prefix</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The prefix of the targeted bot.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">owner</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The ID of the targeted bot's owner.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">ownerTag</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The tag of the targeted bot's owner.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">tags</td>
+      <td style="color: #D9E4EC;">Array</td>
+      <td style="color: #D9E4EC;">An array of the targeted bot's tags.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">views</td>
+      <td style="color: #D9E4EC;">Integer</td>
+      <td style="color: #D9E4EC;">The amount of views the targeted bot's page has gotten.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">submittedOn</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The date the targeted bot was submitted to Universe List.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">approvedOn</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The date the targeted bot was approved on Universe List.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">shortDescription</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The short description of the targeted bot on Universe List.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">description</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The description of the targeted bot on Universe List.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">shards</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The number of shards the targeted bot has.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">servers</td>
+      <td style="color: #D9E4EC;">Integer</td>
+      <td style="color: #D9E4EC;">The number of servers the targeted bot has.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">votes</td>
+      <td style="color: #D9E4EC;">Integer</td>
+      <td style="color: #D9E4EC;">The number of vots the targeted bot has on Universe List.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">invite</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The invite of the targeted bot.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">website</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The website of the targeted bot.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">github</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The github of the targeted bot.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">support</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The support server of the targeted bot.</td>
+    </tbody>
+  </table>
+  <br><br>
+
+  <h3>POST Bot Stats</h3>
+  <p>Posts your bot's server and shard count.</p>
+  <strong>
+    <code class="endpoint">POST /api/bots/:id</code>
+  </strong><br><br>
+  <h4>Headers</h4>
+  <table class="table table-hover">
+    <thead>
+      <th scope="col"><b>Name</b></th>
+      <th scope="col"><b>Type</b></th>
+      <th scope="col"><b>Description</b></th>
+    </thead>
+    <tbody>
+      <td style="color: #D9E4EC;">authorization</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The API Key for the targeted bot.</td>
+    </tbody>
+  </table>
+  <h4>Path Parameters</h4>
+  <table class="table table-hover">
+    <thead>
+      <th scope="col"><b>Name</b></th>
+      <th scope="col"><b>Type</b></th>
+      <th scope="col"><b>Description</b></th>
+    </thead>
+    <tbody>
+      <td style="color: #D9E4EC;">id</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">ID of the bot to post stats for.</td>
+    </tbody>
+  </table>
+  <h4>Request Body</h4>
+  <table class="table table-hover">
+    <thead>
+      <th scope="col"><b>Name</b></th>
+      <th scope="col"><b>Type</b></th>
+      <th scope="col"><b>Description</b></th>
+    </thead>
+    <tbody>
+      <td style="color: #D9E4EC;">server_count</td>
+      <td style="color: #D9E4EC;">Integer</td>
+      <td style="color: #D9E4EC;">The server count for the targeted bot.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">shard_count</td>
+      <td style="color: #D9E4EC;">Integer</td>
+      <td style="color: #D9E4EC;">The shard count for the targeted bot.</td>
+    </tbody>
+  </table>
+  <h4>Response</h4>
+  <table class="table table-hover">
+    <thead>
+      <th scope="col"><b>Name</b></th>
+      <th scope="col"><b>Type</b></th>
+      <th scope="col"><b>Description</b></th>
+    </thead>
+    <tbody>
+      <td style="color: #D9E4EC;">message</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">Error or success message.</td>
+    </tbody>
+  </table>
+  <br><br>
+
+  <h3>GET Bot Votes</h3>
+  <p>Get all votes of a bot on Universe List.</p>
+  <strong>
+    <code class="endpoint">GET /api/bots/:id/votes</code>
+  </strong><br><br>
+  <h4>Path Parameters</h4>
+  <table class="table table-hover">
+    <thead>
+      <th scope="col"><b>Name</b></th>
+      <th scope="col"><b>Type</b></th>
+      <th scope="col"><b>Description</b></th>
+    </thead>
+    <tbody>
+      <td style="color: #D9E4EC;">id</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">ID of the bot to get the votes of.</td>
+    </tbody>
+  </table>
+  <h4>Response</h4>
+  <table class="table table-hover">
+    <thead>
+      <th scope="col"><b>Name</b></th>
+      <th scope="col"><b>Type</b></th>
+      <th scope="col"><b>Description</b></th>
+    </thead>
+    <tbody>
+      <td style="color: #D9E4EC;">user</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The user ID who voted for the bot.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">current</td>
+      <td style="color: #D9E4EC;">Integer</td>
+      <td style="color: #D9E4EC;">The date the user voted.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">next</td>
+      <td style="color: #D9E4EC;">Integer</td>
+      <td style="color: #D9E4EC;">The time unitl they can vote again.</td>
+    </tbody>
+  </table>
+  <br><br>
+
+  <h3>Check Vote</h3>
+  <p>Check if a user voted for your bot.</p>
+  <strong>
+    <code class="endpoint">GET /api/bots/:id/voted/?user=userid</code>
+  </strong><br><br>
+  <h4>Path Parameters</h4>
+  <table class="table table-hover">
+    <thead>
+      <th scope="col"><b>Name</b></th>
+      <th scope="col"><b>Type</b></th>
+      <th scope="col"><b>Description</b></th>
+    </thead>
+    <tbody>
+      <td style="color: #D9E4EC;">id</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The ID of the bot to check the vote on.</td>
+    </tbody>
+  </table>
+  <h4>Query Parameters</h4>
+  <table class="table table-hover">
+    <thead>
+      <th scope="col"><b>Name</b></th>
+      <th scope="col"><b>Type</b></th>
+      <th scope="col"><b>Description</b></th>
+    </thead>
+    <tbody>
+      <td style="color: #D9E4EC;">user</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The ID of the user to check.</td>
+    </tbody>
+  </table>
+  <h4>Response</h4>
+  <table class="table table-hover">
+    <thead>
+      <th scope="col"><b>Name</b></th>
+      <th scope="col"><b>Type</b></th>
+      <th scope="col"><b>Description</b></th>
+    </thead>
+    <tbody>
+      <td style="color: #D9E4EC;">vote</td>
+      <td style="color: #D9E4EC;">Boolean</td>
+      <td style="color: #D9E4EC;">If the user voted or not.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">current</td>
+      <td style="color: #D9E4EC;">Integer</td>
+      <td style="color: #D9E4EC;">The date the user voted.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">next</td>
+      <td style="color: #D9E4EC;">Integer</td>
+      <td style="color: #D9E4EC;">The time unitl they can vote again.</td>
+    </tbody>
+  </table>
+  <br><br>
+
+  <h3>GET Server Information</h3>
+  <p>Returns all information on a server.</p>
+  <strong>
+    <code class="endpoint">GET /api/servers/:id</code>
+  </strong><br><br>
+  <h4>Response</h4>
+  <table class="table table-hover">
+    <thead>
+      <th scope="col"><b>Name</b></th>
+      <th scope="col"><b>Type</b></th>
+      <th scope="col"><b>Description</b></th>
+    </thead>
+    <tbody>
+      <td style="color: #D9E4EC;">name</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The name of the targeted server.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">id</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The ID of the targeted server.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">members</td>
+      <td style="color: #D9E4EC;">Integer</td>
+      <td style="color: #D9E4EC;">The member count of the targeted server.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">icon</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The icon URL of the targeted server.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">invite</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The invite URL of the targeted server.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">submittedOn</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The submitted date of the targeted server.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">website</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The website URL of the targeted server.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">owner</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The owner ID of the targeted server.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">ownerTag</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The owner tag of the targeted server.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">tags</td>
+      <td style="color: #D9E4EC;">Array</td>
+      <td style="color: #D9E4EC;">All of the tags of the targeted server.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">bump</td>
+      <td style="color: #D9E4EC;">Date</td>
+      <td style="color: #D9E4EC;">The latest bump date of the targeted server.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">bumps</td>
+      <td style="color: #D9E4EC;">Integer</td>
+      <td style="color: #D9E4EC;">The number of bumps of the targeted server.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">views</td>
+      <td style="color: #D9E4EC;">Integer</td>
+      <td style="color: #D9E4EC;">The number of views of the targeted server.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">votes</td>
+      <td style="color: #D9E4EC;">Integer</td>
+      <td style="color: #D9E4EC;">The number of votes of the targeted server.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">shortDesc</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The short description of the targeted server.</td>
+      <tr></tr>
+      <td style="color: #D9E4EC;">description</td>
+      <td style="color: #D9E4EC;">String</td>
+      <td style="color: #D9E4EC;">The description of the targeted server.</td>
+      <tr></tr>
+    </tbody>
+  </table>
+  <br><br>
+
+  <h3>Universe List NPM Package</h3>
+  <p>To learn how to interact with our API using JavaScript, check out our NPM package available <a href="https://www.npmjs.com/package/universe-list.js">here</a>.</p>
+  <br><br>
+</div>
 <br><br>
-  <%- include("./parts/footer.ejs") %>
+<%- include("./parts/footer.ejs") %>
+<style>
+  .endpoint {
+    background-color: #2C2F33;
+    border-radius: 5px;
+    padding: 10px;
+  }
+
+  table * {
+    transition-duration: 200ms;
+  }
+</style>

--- a/src/pages/apidocs.ejs
+++ b/src/pages/apidocs.ejs
@@ -37,7 +37,7 @@
       <td style="color: #D9E4EC;">ID of the bot to get information of.</td>
     </tbody>
   </table>
-  <h4>Response</h4>
+  <h4>Response Body</h4>
   <table class="table table-hover">
     <thead>
       <th scope="col"><b>Name</b></th>
@@ -133,7 +133,7 @@
   <strong>
     <code class="endpoint">POST /api/bots/:id</code>
   </strong><br><br>
-  <h4>Headers</h4>
+  <h4>Request Headers</h4>
   <table class="table table-hover">
     <thead>
       <th scope="col"><b>Name</b></th>
@@ -176,7 +176,7 @@
       <td style="color: #D9E4EC;">The shard count for the targeted bot.</td>
     </tbody>
   </table>
-  <h4>Response</h4>
+  <h4>Response Body</h4>
   <table class="table table-hover">
     <thead>
       <th scope="col"><b>Name</b></th>
@@ -209,7 +209,7 @@
       <td style="color: #D9E4EC;">ID of the bot to get the votes of.</td>
     </tbody>
   </table>
-  <h4>Response</h4>
+  <h4>Response Body</h4>
   <table class="table table-hover">
     <thead>
       <th scope="col"><b>Name</b></th>
@@ -263,7 +263,7 @@
       <td style="color: #D9E4EC;">The ID of the user to check.</td>
     </tbody>
   </table>
-  <h4>Response</h4>
+  <h4>Response Body</h4>
   <table class="table table-hover">
     <thead>
       <th scope="col"><b>Name</b></th>
@@ -291,7 +291,7 @@
   <strong>
     <code class="endpoint">GET /api/servers/:id</code>
   </strong><br><br>
-  <h4>Response</h4>
+  <h4>Response Body</h4>
   <table class="table table-hover">
     <thead>
       <th scope="col"><b>Name</b></th>

--- a/src/pages/apidocs.ejs
+++ b/src/pages/apidocs.ejs
@@ -232,7 +232,7 @@
   </table>
   <br><br>
 
-  <h3>Check Vote</h3>
+  <h3>GET Has Voted</h3>
   <p>Check if a user voted for your bot.</p>
   <strong>
     <code class="endpoint">GET /api/bots/:id/voted/?user=userid</code>


### PR DESCRIPTION
These changes intend to improve the API documentation page:

- Adds headers to each of the tables ("Request Headers", "Path Parameters", "Query Parameters" etc...)
- Makes the endpoint text itself stand out (Currently blends in with other text)
- Mention how to obtain an API key

Example screenshot:
![Screenshot 2023-03-26 033643](https://user-images.githubusercontent.com/40654585/227723838-31952060-0cc6-4598-8ab1-0501237a3769.png)

I also did some code clean up, fixed table tags (some tables had their body in the `thead` tag) and made the indentation consistent.