### PR TITLE
Update most link tag targets

### DIFF
--- a/src/pages/apidocs.ejs
+++ b/src/pages/apidocs.ejs
@@ -368,7 +368,7 @@
   <br><br>
 
   <h3>Universe List NPM Package</h3>
-  <p>To learn how to interact with our API using JavaScript, check out our NPM package available <a href="https://www.npmjs.com/package/universe-list.js">here</a>.</p>
+  <p>To learn how to interact with our API using JavaScript, check out our NPM package available <a target="_blank" href="https://www.npmjs.com/package/universe-list.js">here</a>.</p>
   <br><br>
 </div>
 <br><br>

--- a/src/pages/botlist/add.ejs
+++ b/src/pages/botlist/add.ejs
@@ -87,7 +87,7 @@
         </select>
       </div>
       <div class="alert alert-dismissible alert-danger" id="form-error-popup" style="display: none;"></div>
-      <p style="color: #555;">By clicking submit, you agree to our <a style="color: #094cdb" href="https://universe-list.xyz/terms">TOS</a> and the <a style="color: #094cdb" href="https://discord.com/developers/docs/policies-and-agreements/terms-of-service">Discord Developer TOS</a></p>
+      <p style="color: #555;">By clicking submit, you agree to our <a style="color: #094cdb" target="_blank" href="https://universe-list.xyz/terms">TOS</a> and the <a style="color: #094cdb" target="_blank" href="https://discord.com/developers/docs/policies-and-agreements/terms-of-service">Discord Developer TOS</a></p>
       <button type="submit" class="bluebtn"><i class="fa-solid fa-paper-plane"></i>&nbsp&nbspSubmit</button>
     </form>
   </div>

--- a/src/pages/botlist/certify.ejs
+++ b/src/pages/botlist/certify.ejs
@@ -42,9 +42,9 @@
                     autocomplete="off" required>
                 </div>
                 <div class="alert alert-dismissible alert-danger" id="form-error-popup" style="display: none;"></div>
-                <p style="color: #555;">By clicking submit, you agree to our <a style="color: #094cdb"
-                    href="https://universe-list.xyz/terms">TOS</a>, <a style="color: #094cdb" href="https://universe-list.xyz/certification">Certification Guidelines,</a> and the <a style="color: #094cdb"
-                    href="https://discord.com/developers/docs/policies-and-agreements/terms-of-service">Discord
+                <p style="color: #555;">By clicking submit, you agree to our <a style="color: #094cdb" target="_blank"
+                    href="https://universe-list.xyz/terms">TOS</a>, <a style="color: #094cdb" target="_blank" href="https://universe-list.xyz/certification">Certification Guidelines,</a> and the <a style="color: #094cdb"
+                    target="_blank" href="https://discord.com/developers/docs/policies-and-agreements/terms-of-service">Discord
                     Developer TOS</a></p>
                 <button type="submit" class="bluebtn"><i class="fa-solid fa-paper-plane"></i> Submit</button>
               </form>

--- a/src/pages/botlist/delete.ejs
+++ b/src/pages/botlist/delete.ejs
@@ -15,7 +15,7 @@
   <a href="/">
     <button style="margin:5px" class="errorhome"><i class="fa-solid fa-house-chimney"></i> Home</button>
     </div></a>
-  <a href="/discord">
+  <a target="_blank" href="/discord">
     <button class="errordiscord"><i class="fa-brands fa-discord"></i> Discord</button></a>
   </div></a>
 </center>

--- a/src/pages/botlist/edit.ejs
+++ b/src/pages/botlist/edit.ejs
@@ -99,7 +99,7 @@
         </select>
       </div>
       <div class="alert alert-dismissible alert-danger" id="form-error-popup" style="display: none;"></div>
-      <p style="color: #555;">By clicking submit, you agree to our <a style="color: #094cdb" href="https://universe-list.xyz/terms">TOS</a> and the <a style="color: #094cdb" href="https://discord.com/developers/docs/policies-and-agreements/terms-of-service">Discord Developer TOS</a></p>
+      <p style="color: #555;">By clicking submit, you agree to our <a style="color: #094cdb" target="_blank" href="https://universe-list.xyz/terms">TOS</a> and the <a style="color: #094cdb" target="_blank" href="https://discord.com/developers/docs/policies-and-agreements/terms-of-service">Discord Developer TOS</a></p>
        <button type="submit" class="bluebtn"><i class="fa-solid fa-paper-plane"></i> Submit</button>
     </form>
     <form class="deleteForm" method="POST" action="/bots/<%= bot.id %>/delete">

--- a/src/pages/botlist/viewbot.ejs
+++ b/src/pages/botlist/viewbot.ejs
@@ -60,13 +60,13 @@
           <% } %>
           <% if (user) { %>
             <% if (!bot.owner.includes(user.id)) { %>
-              <a target="blank" href="/bots/<%= bot.id %>/review" type="button" style="border-radius: 5px;" class="btn btn-info pr-3 pl-3 mr-1"><i class="fa-solid fa-pen-to-square"></i> Review</a>
+              <a href="/bots/<%= bot.id %>/review" type="button" style="border-radius: 5px;" class="btn btn-info pr-3 pl-3 mr-1"><i class="fa-solid fa-pen-to-square"></i> Review</a>
               <% } %>
           <% if (bot.owner.includes(user.id) || member.roles.cache.some((role) => role.id === config.roles.bottester)) { %>
-          <a target="blank" href="/bots/<%= bot.id %>/edit" type="button" style="border-radius: 5px;" class="btn btn-warning pr-3 pl-3 mr-1"><i class="fa-solid fa-pen-to-square"></i> Edit</a>
+          <a href="/bots/<%= bot.id %>/edit" type="button" style="border-radius: 5px;" class="btn btn-warning pr-3 pl-3 mr-1"><i class="fa-solid fa-pen-to-square"></i> Edit</a>
           <% } %>
           <% if (bot.owner.includes(user.id)) { %>
-            <a target="blank" href="/bots/<%= bot.id %>/certify" type="button" style=" background-color: #ff5f5f; border-radius: 5px;"
+            <a href="/bots/<%= bot.id %>/certify" type="button" style=" background-color: #ff5f5f; border-radius: 5px;"
               class="btn btn-warning pr-3 pl-3 mr-1"><i class="fa-solid fa-square-check"></i> Certify</a>
             <% } %>
           <% } %>

--- a/src/pages/errors/403.ejs
+++ b/src/pages/errors/403.ejs
@@ -15,7 +15,7 @@
     <a href="/">
       <button style="margin:5px" class="errorhome"><i class="fa-solid fa-house-chimney"></i> Home</button>
       </div></a>
-    <a href="/discord">
+    <a target="_blank" href="/discord">
       <button class="errordiscord"><i class="fa-brands fa-discord"></i> Discord</button></a>
     </div></a>
   </center>

--- a/src/pages/errors/404.ejs
+++ b/src/pages/errors/404.ejs
@@ -15,7 +15,7 @@
   <a href="/">
     <button style="margin:5px" class="errorhome"><i class="fa-solid fa-house-chimney"></i> Home</button>
     </div></a>
-  <a href="/discord">
+  <a target="_blank" href="/discord">
     <button class="errordiscord"><i class="fa-brands fa-discord"></i> Discord</button></a>
   </div></a>
 </center>

--- a/src/pages/errors/503.ejs
+++ b/src/pages/errors/503.ejs
@@ -12,7 +12,7 @@
 <center>
   <h2 style="margin-top: 100px;"><b>503 Service Unavailable:</b></h2>
   <p style="color:white;font-size: 15">We're terribly sorry, But we're down for maintenanace. Check our Discord Server for updates!</p><br>
-  <a href="/discord">
+  <a target="_blank" href="/discord">
     <button class="errorhome"><i class="fa-brands fa-discord"></i> Discord</button>
     </div></a>
   <a href="/auth/login">

--- a/src/pages/partners.ejs
+++ b/src/pages/partners.ejs
@@ -15,7 +15,7 @@
               <img src="https://universe-list.xyz/img/icon.png" alt="Unknown Icon" draggable="false" class="botimg_main">
               <p class="botname_main" style="height:65px;width:250px;padding:10px;"> 
                 No Partners... <br>
-                <span style="font-size:15px; font-weight:normal;"><i class="fa-solid fa-crown"></i> Owner: <a href="/users/998763334264442912" style="text-decoration: none;font-size:15px; color: white"> N/A</a>
+                <span style="font-size:15px; font-weight:normal;"><i class="fa-solid fa-crown"></i> Owner: <a target="_blank" href="/users/998763334264442912" style="text-decoration: none;font-size:15px; color: white"> N/A</a>
               </p>
               <div class="botdesc_main" style="cardcss">
                 <i class="fa-solid fa-file-lines"></i> This could be your awesome project! DM Ishaantek#0001 to become a partner!
@@ -24,11 +24,11 @@
                 <i class="fa-solid fa-hashtag"></i> Partners
               </div>
               <div style="margin-left:20px;margin-top:-40px">
-                <a href="https://universe-list.xyz">
+                <a target="_blank" href="https://universe-list.xyz">
                   <button class="viewbtn">Website</button>
               </div>
             </a>
-            <a href="https://universe-list.xyz">
+            <a target="_blank" href="https://universe-list.xyz/discord">
               <button class="votebtn">Discord</button></a>
           </div></a>
         </div>

--- a/src/pages/parts/navbar.ejs
+++ b/src/pages/parts/navbar.ejs
@@ -74,7 +74,7 @@
             <a class="dropdown-item" target="blank" href="https://status.universe-list.xyz/"
               ><i class="fa-solid fa-signal"></i>&nbsp;&nbsp;Status Page</a
             >
-            <a class="dropdown-item" href="/discord"
+            <a target="_blank" class="dropdown-item" href="/discord"
               ><i class="fa-brands fa-discord"></i>&nbsp;&nbsp;Discord</a
             >
           </div>

--- a/src/pages/queue/index.ejs
+++ b/src/pages/queue/index.ejs
@@ -78,9 +78,8 @@
           <td style="color: #D9E4EC;">
             <a target="__blank" style="border-radius: 5px;" href="https://discordapp.com/oauth2/authorize?client_id=<%= inprogress[i].id %>&scope=bot&permissions=0&guild_id=<%= global.config.guilds.testing %>" class="btn btn-primary">Invite</a>
             <a href="/bots/<%= inprogress[i].id%>" type="button" style="border-radius: 5px;" class="btn btn-warning">View</a>
-            <a target="__blank" href="/bots/<%= inprogress[i].id %>/approve" style="border-radius: 5px;" class="btn btn-success">Approve</a>
-
-            <a target="__blank" href="/bots/<%= inprogress[i].id %>/deny" class="btn btn-danger" style="border-radius: 5px;">Deny</a>
+            <a href="/bots/<%= inprogress[i].id %>/approve" style="border-radius: 5px;" class="btn btn-success">Approve</a>
+            <a href="/bots/<%= inprogress[i].id %>/deny" class="btn btn-danger" style="border-radius: 5px;">Deny</a>
           </td>
           <td>
             <%- inprogress[i].reviewer %>

--- a/src/pages/servers/editserver.ejs
+++ b/src/pages/servers/editserver.ejs
@@ -54,7 +54,7 @@
         </select>
       </div>
       <div class="alert alert-dismissible alert-danger" id="form-error-popup" style="display: none;"></div>
-      <p style="color: #555;">By clicking submit, you agree to our <a style="color: #094cdb" href="https://universe-list.xyz/terms">TOS</a> and the <a style="color: #094cdb" href="https://discord.com/developers/docs/policies-and-agreements/terms-of-service">Discord Developer TOS</a></p>
+      <p style="color: #555;">By clicking submit, you agree to our <a style="color: #094cdb" target="_blank" href="https://universe-list.xyz/terms">TOS</a> and the <a style="color: #094cdb" target="_blank" href="https://discord.com/developers/docs/policies-and-agreements/terms-of-service">Discord Developer TOS</a></p>
       <button type="submit" class="bluebtn"><i class="fa-solid fa-paper-plane"></i>&nbsp&nbspSubmit</button>
       <!--<a href="/servers/<%= server.id %>/delete" type="button" style="border-radius: 5px;" class="btn btn-danger pr-3 pl-3 mr-1"><i class="fa-solid fa-trash"></i>  Delete</a>-->
     </form>

--- a/src/pages/servers/index.ejs
+++ b/src/pages/servers/index.ejs
@@ -72,7 +72,7 @@
       <a href="/servers/<%= bumped[i].id %>/">
         <button class="viewbtn">View</button>
     </div></a>
-    <a href="/servers/<%= bumped[i].id %>/join">
+    <a target="_blank" href="/servers/<%= bumped[i].id %>/join">
       <button class="joinbtn">Join</button></a>
   </div></a>
   <% } %><br><br><br><br><br>
@@ -98,7 +98,7 @@
       <a href="/servers/<%= members[i].id %>/">
         <button class="viewbtn">View</button>
     </div></a>
-    <a href="/servers/<%= members[i].id %>/join">
+    <a target="_blank" href="/servers/<%= members[i].id %>/join">
       <button class="joinbtn">Join</button></a>
   </div></a>
   <% } %><br><br><br><br>
@@ -125,7 +125,7 @@
       <a href="/servers/<%= voted[i].id %>/">
         <button class="viewbtn">View</button>
     </div></a>
-    <a href="/servers/<%= voted[i].id %>/join">
+    <a target="_blank" href="/servers/<%= voted[i].id %>/join">
       <button class="joinbtn">Join</button></a>
   </div></a>
   <% } %>

--- a/src/pages/servers/viewserver.ejs
+++ b/src/pages/servers/viewserver.ejs
@@ -39,12 +39,9 @@
           <% if (server.website) { %>
           <a target="blank" href="<%= server.website %>" type="button" style="border-radius: 5px;" class="btn btn-info pr-3 pl-3 mr-1"><i class="fa-solid fa-globe"></i> Website</a>
           <% } %>
-          <% if (server.support) { %>
-          <a target="blank" href="https://discord.gg/<%= bot.support %>" type="button" style="border-radius: 5px;" class="btn btn-info pr-3 pl-3 mr-1"><i class="fa-brands fa-discord"></i> Support</a>
-          <% } %>
           <% if (user) { %>
           <% if (server.owner.includes(user.id)) { %>
-          <a target="blank" href="/servers/<%= server.id %>/edit" type="button" style="border-radius: 5px;" class="btn btn-warning pr-3 pl-3 mr-1"><i class="fa-solid fa-pen-to-square"></i> Edit</a>
+          <a href="/servers/<%= server.id %>/edit" type="button" style="border-radius: 5px;" class="btn btn-warning pr-3 pl-3 mr-1"><i class="fa-solid fa-pen-to-square"></i> Edit</a>
           <% } %>
           <% } %>
         </div>

--- a/src/pages/user.ejs
+++ b/src/pages/user.ejs
@@ -39,7 +39,7 @@
         </hr>
         <% if (user) { %>
         <% if (fetched_user.id === user.id) { %>
-        <a target="blank" href="/users/<%= fetched_user.id %>/edit" type="button" style="border-radius: 5px;" class="btn btn-info pr-3 pl-3 mr-1"><i class="fa-solid fa-pen-to-square"></i> Edit Profile</a>
+        <a href="/users/<%= fetched_user.id %>/edit" type="button" style="border-radius: 5px;" class="btn btn-info pr-3 pl-3 mr-1"><i class="fa-solid fa-pen-to-square"></i> Edit Profile</a>
         <% } %>
         <% } %>
         <a target="blank" href="https://discord.com/users/<%= fetched_user.id %>" type="button" style="border-radius: 5px;" class="btn btn-info pr-3 pl-3 mr-1"><i class="fa-brands fa-discord"></i> Discord</a>


### PR DESCRIPTION
These changes attempt to improve the links by adding, and in some cases removing, the `target="_blank"`.

What I've done is:
- All links that leave the website, now open in a new tab (this way the user stays on the site longer)
- On pages that offer ways to edit content, there are links to policies, these will now open in a new tab (to prevent losing unsaved changes)
- The buttons leading to `/edit` & `/review` pages currently open in new tabs, this is unneeded as both the browser back button and the submit lead back to the bot (or server) page