### PR TITLE
Fix login return to not working

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -220,11 +220,8 @@ app.get("/info", async (req, res) => {
 
 app.get("/auth/logout", function (req, res) {
   req.logout(() => {
-    res.redirect("/");
+    res.redirect(req.query.from || "/");
   });
-  if (req.session.returnTo) {
-    delete req.session.returnTo;
-  }
 });
 
 //-bot-//

--- a/src/app.js
+++ b/src/app.js
@@ -153,26 +153,24 @@ let normalScopes = ["identify"];
 
 app.get(
   "/auth/login",
-  passport.authenticate("discord", {
-    scope: normalScopes,
-    prompt: prompt,
-    callbackURL: config.bot.redirect,
-  }),
-  (req, res) => {
-    if (req.query.from) req.session.returnTo = req.query.from;
-  }
+  (req, res, next) =>
+    passport.authenticate("discord", {
+      scope: normalScopes,
+      prompt: prompt,
+      callbackURL: config.bot.redirect,
+      state: req.query.from || '/',
+    })(req, res, next)
 );
 
 app.get(
   "/auth/login/joinSupport",
-  passport.authenticate("discord", {
-    scope: scopes,
-    prompt: prompt,
-    callbackURL: `${config.bot.redirect}/joinSupport`,
-  }),
-  (req, res) => {
-    if (req.query.from) req.session.returnTo = req.query.from;
-  }
+  (req, res, next) => 
+    passport.authenticate("discord", {
+      scope: scopes,
+      prompt: prompt,
+      callbackURL: `${config.bot.redirect}/joinSupport`,
+      state: req.query.from || '/',
+    })(req, res, next)
 );
 
 app.get(
@@ -181,7 +179,7 @@ app.get(
     failureRedirect: "/",
   }),
   function (req, res) {
-    res.redirect(req.session.returnTo || "/");
+    res.redirect(req.query.state || "/");
   }
 );
 
@@ -212,7 +210,7 @@ app.get(
       );
     } catch {}
 
-    res.redirect(req.session.returnTo || "/");
+    res.redirect(req.query.state || "/");
   }
 );
 

--- a/src/pages/parts/navbar.ejs
+++ b/src/pages/parts/navbar.ejs
@@ -157,11 +157,9 @@
       confirmButtonText: "Yes",
       denyButtonText: `No`,
     }).then((result) => {
-      if (result.isConfirmed) {
-        window.location.replace("/auth/login/joinSupport");
-      } else if (result.isDenied) {
-        window.location.replace("/auth/login");
-      }
+      const from = window.location.pathname;
+      const path = result.isConfirmed ? "/auth/login/joinSupport" : "/auth/login";
+      window.location.replace(`${path}?from=${from}`);
     });
   }
 </script>

--- a/src/pages/parts/navbar.ejs
+++ b/src/pages/parts/navbar.ejs
@@ -116,7 +116,7 @@
           <a class="dropdown-item" href="/servers/new"
             ><i class="fa-solid fa-plus"></i>&nbsp;&nbsp;Add Server</a
           >
-          <a class="dropdown-item" href="/auth/logout"
+          <a class="dropdown-item" onclick="logout()" style="cursor: pointer;"
             ><i class="fa-solid fa-right-from-bracket"></i>&nbsp;&nbsp;Logout</a
           >
           <% if(config.staff.includes(user.id)) { %>
@@ -161,5 +161,10 @@
       const path = result.isConfirmed ? "/auth/login/joinSupport" : "/auth/login";
       window.location.replace(`${path}?from=${from}`);
     });
+  }
+  function logout() {
+    const from = window.location.pathname;
+      const path = "/auth/logout";
+      window.location.replace(`${path}?from=${from}`);
   }
 </script>


### PR DESCRIPTION
The current setup uses `req.session.returnTo` to store the redirect path, then attempts to access it during the callback, this isn't currently working for a number of reasons. I tried a few things to get it to work but session isn't persisting between the login and callback routes and I don't know why.

This pull request utilises a different method. Here the `state` query parameter of the Discord OAuth is used to store the redirect URL. Discord passes the `state` parameter back to the callback URL, where we use it to redirect the user to their original page. I'll share a video in Discord of it working shortly.