### PR TITLE
feat: Add global.botModel to guildMemberRemove event

### DIFF
--- a/mainbot/events/guildMemberRemove.js
+++ b/mainbot/events/guildMemberRemove.js
@@ -1,5 +1,5 @@
 const { EmbedBuilder } = require("@discordjs/builders");
-
+const Bot = global.botModel
 module.exports = {
   async run(client, member) {
     if (member.guild.id !== global.config.guilds.main) return;


### PR DESCRIPTION
The global botModel is now imported into guildMemberRemove event for easy access to the bot model across different files in the codebase.