### PR TITLE
Refactor: Get member tag as a string in guildMemberRemove.js

### DIFF
--- a/mainbot/events/guildMemberRemove.js
+++ b/mainbot/events/guildMemberRemove.js
@@ -22,7 +22,7 @@ module.exports = {
           const botMember = await guild.members.fetch(bot.id);
           if (botMember) {
             bot_kick.addFields({
-              name: botMember.user.tag,
+              name: String(botMember.user.tag),
               value: `<@${botMember.id}> has been removed.`,
               inline: true,
             });


### PR DESCRIPTION
Instead of having a member tag that is not a string value, the commit updates the code to have a consistent member tag string in guildMemberRemove.js.